### PR TITLE
[Feature] Include reviewable when creating review logs

### DIFF
--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -35,4 +35,5 @@ export default OsfModel.extend({
     primaryFile: DS.belongsTo('file', { inverse: null }),
     provider: DS.belongsTo('preprint-provider', { inverse: 'preprints', async: true }),
     reviewLogs: DS.hasMany('review-log', { inverse: 'reviewable', async: true }),
+    contributors: DS.hasMany('contributors', { async: true }),
 });

--- a/addon/serializers/node.js
+++ b/addon/serializers/node.js
@@ -2,26 +2,8 @@ import Ember from 'ember';
 import OsfSerializer from './osf-serializer';
 
 export default OsfSerializer.extend({
-    serialize(snapshot) {
-        // Normal OSF serializer strips out relationships. We need to add back primaryFile/node/provider for this endpoint
-        const res = this._super(...arguments);
-        res.data.relationships = {};
-        let hasRelation = false;
-        for (var rel in snapshot.record._dirtyRelationships) {
-            let relationship = Ember.String.underscore(rel);
-            if (relationship.includes('license')) {
-                res.data.relationships[relationship] = {
-                    data: {
-                        id: snapshot.belongsTo(rel, { id: true }),
-                        type: 'licenses'
-                    }
-                };
-                hasRelation = true;
-            }
-        }
-        if (!hasRelation) {
-            delete res.data.relationships;
-        }
-        return res;
-    }
+    // Serialize license relationship
+    relationshipTypes: {
+        license: 'licenses',
+    },
 });

--- a/addon/serializers/preprint.js
+++ b/addon/serializers/preprint.js
@@ -2,31 +2,18 @@ import OsfSerializer from './osf-serializer';
 import Ember from 'ember';
 
 export default OsfSerializer.extend({
-    serialize(snapshot) {
-        // Normal OSF serializer strips out relationships. We need to add back primaryFile/node/provider for this endpoint
-        const res = this._super(...arguments);
-        res.data.relationships = {};
-        for (var rel in snapshot.record._dirtyRelationships) {
-            let relationship = Ember.String.underscore(rel);
-            res.data.relationships[relationship] = {
-                data: {
-                    id: snapshot.belongsTo(rel, { id: true }),
-                    type: relTypes[rel]
-                }
-            };
-        }
+    // Serialize these relationships
+    relationshipTypes: {
+        primaryFile: 'files',
+        node: 'nodes',
+        provider: 'providers',
+        license: 'licenses',
+    },
 
+    serialize(snapshot) {
+        const res = this._super(...arguments);
         if (res.data.attributes && 'subjects' in snapshot.record.changedAttributes())
             res.data.attributes.subjects = (snapshot.record.get('subjects') || []);
         return res;
-    }
-
+    },
 });
-
-// Type mapping for preprint relationship fields
-const relTypes = {
-    primaryFile: 'files',
-    node: 'nodes',
-    provider: 'providers',
-    license: 'licenses',
-};

--- a/addon/serializers/review-log.js
+++ b/addon/serializers/review-log.js
@@ -1,4 +1,26 @@
 import OsfSerializer from './osf-serializer';
+import Ember from 'ember';
 
 export default OsfSerializer.extend({
+    serialize(snapshot) {
+        // Normal OSF serializer strips out relationships. We need to add back reviewable for this endpoint
+        const res = this._super(...arguments);
+        res.data.relationships = {};
+        for (var rel in snapshot.record._dirtyRelationships) {
+            let relationship = Ember.String.underscore(rel);
+            res.data.relationships[relationship] = {
+                data: {
+                    id: snapshot.belongsTo(rel, { id: true }),
+                    type: relTypes[rel]
+                }
+            };
+        }
+        return res;
+    }
+
 });
+
+// Type mapping for relationship fields
+const relTypes = {
+    reviewable: 'preprints',
+};

--- a/addon/serializers/review-log.js
+++ b/addon/serializers/review-log.js
@@ -2,25 +2,8 @@ import OsfSerializer from './osf-serializer';
 import Ember from 'ember';
 
 export default OsfSerializer.extend({
-    serialize(snapshot) {
-        // Normal OSF serializer strips out relationships. We need to add back reviewable for this endpoint
-        const res = this._super(...arguments);
-        res.data.relationships = {};
-        for (var rel in snapshot.record._dirtyRelationships) {
-            let relationship = Ember.String.underscore(rel);
-            res.data.relationships[relationship] = {
-                data: {
-                    id: snapshot.belongsTo(rel, { id: true }),
-                    type: relTypes[rel]
-                }
-            };
-        }
-        return res;
-    }
-
+    // Serialize reviewable relationship
+    relationshipTypes: {
+        reviewable: 'preprints',
+    },
 });
-
-// Type mapping for relationship fields
-const relTypes = {
-    reviewable: 'preprints',
-};


### PR DESCRIPTION
# Purpose
The default serializer strips out all relationships when you create a thing -- don't do that for review logs.

# Summary of changes
Copy most of the preprint serializer which replaces dirty relationships after the base serializer strips them out. There are several ways this could be done better, but right now I'm just getting things to work.

