### PR TITLE
[Fix] Use `getRecords()` instead of `.record`

### DIFF
--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -150,13 +150,13 @@ export default OsfModel.extend(FileItemMixin, {
         var contributors = this.hasMany('contributors').hasManyRelationship;
         this.set(
             '_dirtyRelationships.contributors.update',
-            contributors.members.list.filter(m => !m.record.get('isNew') && Object.keys(m.record.changedAttributes()).length > 0)
+            contributors.members.list.filter(m => !m.getRecord().get('isNew') && Object.keys(m.getRecord().changedAttributes()).length > 0)
         );
         // Need to included created contributors even in relationship
         // hasLoaded is false
         this.set(
             '_dirtyRelationships.contributors.create',
-            contributors.members.list.filter(m => m.record.get('isNew'))
+            contributors.members.list.filter(m => m.getRecord().get('isNew'))
         );
         // Contributors are a 'real' delete, not just a de-reference
         this.set(

--- a/addon/models/osf-model.js
+++ b/addon/models/osf-model.js
@@ -57,12 +57,12 @@ export default DS.Model.extend(HasManyQuery.ModelMixin, {
             var relation = this.resolveRelationship(rel);
             // TODO(samchrisinger): not sure if hasLoaded is a subset if the hasData state
             if (relation.hasData && relation.hasLoaded) {
-                var canonicalIds = relation.canonicalMembers.list.map(member => member.record.get('id'));
-                var currentIds = relation.members.list.map(member => member.record.get('id'));
+                var canonicalIds = relation.canonicalMembers.list.map(member => member.getRecord().get('id'));
+                var currentIds = relation.members.list.map(member => member.getRecord().get('id'));
                 var changes = {
-                    create: relation.members.list.filter(m => m.record.get('isNew')),
-                    add: relation.members.list.filter(m => !m.record.get('isNew') && canonicalIds.indexOf(m.record.get('id')) === -1),
-                    remove: relation.canonicalMembers.list.filter(m => currentIds.indexOf(m.record.get('id')) === -1)
+                    create: relation.members.list.filter(m => m.getRecord().get('isNew')),
+                    add: relation.members.list.filter(m => !m.getRecord().get('isNew') && canonicalIds.indexOf(m.getRecord().get('id')) === -1),
+                    remove: relation.canonicalMembers.list.filter(m => currentIds.indexOf(m.getRecord().get('id')) === -1)
                 };
 
                 var other = this.get('_dirtyRelationships.${rel}') || {};


### PR DESCRIPTION
# Purpose
Fix saving models with relationships. Ember removed `.record` in version 2.14 in favor of the existing `getRecord()` method, see https://github.com/emberjs/data/pull/4901.

For more info see the [change log](https://github.com/emberjs/data/blob/release/CHANGELOG.md#release-2140-june-18-2017), h/t @aaxelb.

This does not impact snapshots.

# Summary of changes
`.record` --> `getRecord()`

